### PR TITLE
Move the Security metadata from the Keptn core repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# SECURITY
+
+This page borrows parts of its contents from https://kubernetes.io/security/
+
+## Report a Vulnerability
+
+We are extremely grateful for security researchers and users that report vulnerabilities to the Keptn Open Source Community. All reports are thoroughly investigated by a set of community members.
+
+To make a report, submit your vulnerability to all security contacts of Keptn [listed below](#security-contacts). This allows triage and handling of the vulnerability with standardized response times.
+
+### When Should I Report a Vulnerability?
+
+- You think you discovered a potential security vulnerability in Keptn
+- You are unsure how a vulnerability affects Keptn
+- You think you discovered a vulnerability in another project that Keptn depends on. For projects with their own vulnerability reporting and disclosure process, please report it directly there.
+
+### When Should I NOT Report a Vulnerability?
+
+- You need help tuning Keptn components for security - please discuss this is in the various Keptn community channels
+- You need help applying security-related updates
+- Your issue is not security-related
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the security contacts within 5 working days. This will set off the [Security Release Process](#process).
+
+Any vulnerability information shared with the Keptn security contacts stays within Keptn project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+## Public Disclosure Timing
+
+A public disclosure date is negotiated by the Keptn Security Committee and the bug submitter. We prefer to fully disclose the bug as soon as possible once a user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it is already publicly known) to a few weeks. For a vulnerability with a straightforward mitigation, we expect report date to disclosure date to be on the order of 7 days. The Keptn Security Committee holds the final say when setting a disclosure date.
+
+## Process
+
+If you find a security-related bug in Keptn, we kindly ask you for responsible disclosure and for giving us appropriate time to react, analyze, and develop a fix to mitigate the found security vulnerability. The security contact will investigate the issue within 5 working days.
+
+The team will react promptly to fix the security issue and its workaround/fix will be [published on our website](https://keptn.sh/docs/news/vulnerability_bulletins/) along with a classification of the security issue.
+
+## Security Contacts
+
+Defined below are the security contacts for this repository. In case you identify any security issue, please reach out to all of the security contacts.
+
+- johannes.braeuer
+- andreas.grimmer
+- christian.kreuzberger
+- giovanni.liva
+
+Please append the email addresses with [at] dynatrace [.com] and address your email to all security contacts.


### PR DESCRIPTION
Makes the security metadata available for all repositories. Downstream PR:  https://github.com/keptn/keptn/pull/7145

Signed-off-by: Oleg Nenashev <o.v.nenashev@dynatrace.com>